### PR TITLE
bookmarks.txt is a bad name. 

### DIFF
--- a/booky.sh
+++ b/booky.sh
@@ -7,7 +7,9 @@ pdf_data="${pdf%.*}""_data.txt"
 bkFile="$2"
 
 echo "Converting $bkFile to pdftk compatible format"
-python3 booky.py < "$bkFile" > bookmarks-pdftk-compatible.txt
+#python3 booky.py < "$bkFile" > bookmarks-pdftk-compatible.txt
+# my setting for alias
+python3 ~/booky/booky.py < "$bkFile" > bookmarks-pdftk-compatible.txt
 
 echo "Dumping pdf meta data..."
 pdftk "$pdf" dump_data_utf8 output "$pdf_data"

--- a/booky.sh
+++ b/booky.sh
@@ -7,7 +7,7 @@ pdf_data="${pdf%.*}""_data.txt"
 bkFile="$2"
 
 echo "Converting $bkFile to pdftk compatible format"
-python3 booky.py < "$bkFile" > bookmarks.txt
+python3 booky.py < "$bkFile" > bookmarks-pdftk-compatible.txt
 
 echo "Dumping pdf meta data..."
 pdftk "$pdf" dump_data_utf8 output "$pdf_data"
@@ -16,10 +16,10 @@ echo "Clear dumped data of any previous bookmarks"
 sed -i '/Bookmark/d' "$pdf_data"
 
 echo "Inserting your bookmarks in the data"
-sed -i '/NumberOfPages/r bookmarks.txt' "$pdf_data"
+sed -i '/NumberOfPages/r bookmarks-pdftk-compatible.txt' "$pdf_data"
 
 echo "Creating new pdf with your bookmarks..."
 pdftk "$pdf" update_info_utf8 "$pdf_data" output "${pdf%.*}""_new.pdf"
 
 echo "Deleting leftovers"
-rm bookmarks.txt "$pdf_data"
+rm bookmarks-pdftk-compatible.txt "$pdf_data"

--- a/increment.py
+++ b/increment.py
@@ -1,0 +1,44 @@
+#!/usr/local/bin/python3
+"""This module does nothing"""
+import re
+import os
+
+
+def increment_pagenum(mystr, num):
+    """input: (string, counter) / output: replaced string """
+    regex_pattern = re.search(r",\s*(\d+)", mystr)
+    if regex_pattern == None:
+        return mystr
+    else:
+        print("regex_pattern.group(1) is", regex_pattern.group(1))
+        new_page = int(regex_pattern.group(1))+num
+        #new_str = re.sub(r'(.*,\s*)\d+', r'\1 %s' % str(new_page), mystr)
+        #new_str = re.sub(r'(.*,\s*)\d+', r"\1 {}".format(str(new_page)), mystr) # not working either
+        new_str = re.sub(r'(.*,)\s*\d+', r'\1 %s' % str(new_page), mystr)
+        return new_str
+
+
+
+def main():
+    """ main """
+    bmf = open(os.path.expanduser("~/booky/mybookmarks.txt"), "r")
+    lines = bmf.readlines()
+    #for i in range(len(lines)):
+        #print("i -> value:", i)
+        #print("lines[i]'s value:", lines[i])
+        #lines[i] = lines[i].strip()
+        #print("lines[i]'s value:", lines[i])
+    print("lines's value:", lines)
+
+    print("start")
+    for i in range(len(lines)):
+        print("i -> value:", i)
+        lines[i] = increment_pagenum(lines[i],1)
+        print("lines[", i, "]'s value:", lines[i])
+    for line in lines:
+        print(line)
+    new_bmf = open(os.path.expanduser("~/booky/mynewbookmarks.txt"), "w")
+    new_bmf.writelines(lines)
+
+main()
+

--- a/increment.py
+++ b/increment.py
@@ -12,9 +12,20 @@ def increment_pagenum(mystr, num):
     else:
         print("regex_pattern.group(1) is", regex_pattern.group(1))
         new_page = int(regex_pattern.group(1))+num
+        replace_pattern = r'\g<1>'+re.escape(str(new_page))
+        print("replace_pattern -> value:", replace_pattern)
         #new_str = re.sub(r'(.*,\s*)\d+', r'\1 %s' % str(new_page), mystr)
-        #new_str = re.sub(r'(.*,\s*)\d+', r"\1 {}".format(str(new_page)), mystr) # not working either
-        new_str = re.sub(r'(.*,)\s*\d+', r'\1 %s' % str(new_page), mystr)
+        #new_str = re.sub(r'(.*,\s*)\d+', r"\1 {}".format(str(new_page)), mystr) # not working
+        #new_str = re.sub(r'(.*,)\s*\d+', r'\1 %s' % str(new_page), mystr)
+        #new_str = re.sub(r'(.*,)\s*\d+', replace_pattern, mystr) # progressing...
+        #new_str = re.sub(r'(.*,)\s*\d+', r'\g<1>%s' % str(new_page), mystr) # This works!!!
+### three lines come together ###
+        replace_pattern = r'\g<1>'+re.escape(str(new_page))
+        print("replace_pattern -> value:", replace_pattern)
+        new_str = re.sub(r'(.*,)\s*\d+', replace_pattern, mystr) # and this also works!!!
+### ###
+
+
         return new_str
 
 
@@ -29,8 +40,6 @@ def main():
         #lines[i] = lines[i].strip()
         #print("lines[i]'s value:", lines[i])
     print("lines's value:", lines)
-
-    print("start")
     for i in range(len(lines)):
         print("i -> value:", i)
         lines[i] = increment_pagenum(lines[i],1)


### PR DESCRIPTION
In fact, I kept on using this name 'bookmarks.txt' for my file that contains the custom bookmark formats (i.e. $2 argument) and constantly crashed until I realized that this name was already being used by the script itself. I changed the name 'bookmarks.txt' to 'mybookmarks.txt' and it worked perfect and I'm satisfied with it, thanks for creating this script btw, but I wish others not repeat the same bug I encountered.

So I changed the script itself instead, from 'bookmarks.txt' to 'bookmarks-pdftk-compatible.txt'. I guess nobody will use this name for their own bookmark files, so we are good.