### PR TITLE
Document dependence on GNU sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ this script to enter bookmarks data in a simple format.
 * pdftk
 * dirname
 * basename
+* GNU sed
 
 ## Bookmark format
 * Every level starts with a `{` on a _separate line_.


### PR DESCRIPTION
First of all, just wanted to thank you for all the time you just saved me!

Your scripts worked for me with only one small change. OS X by default only has BSD sed installed, which doesn't have the same behavior for the `-i` flag as GNU sed. I happen to have GNU sed installed (available as `gsed` to not interfere with the OS X defaults).

I thought I'd point this out in case anyone else ran into similar issues.

Thanks again!