### PR TITLE
Use double quotes (not single quotes)

### DIFF
--- a/booky.sh
+++ b/booky.sh
@@ -8,7 +8,7 @@ EXTRACT_FILE=booky_bookmarks_extract
 bkFile="$2"
 
 echo "Converting $bkFile to pdftk compatible format"
-python3 booky.py < "$bkFile" > $EXTRACT_FILE
+python3 booky.py < "$bkFile" > "$EXTRACT_FILE"
 
 echo "Dumping pdf meta data..."
 pdftk "$pdf" dump_data_utf8 output "$pdf_data"
@@ -17,10 +17,10 @@ echo "Clear dumped data of any previous bookmarks"
 sed -i '/Bookmark/d' "$pdf_data"
 
 echo "Inserting your bookmarks in the data"
-sed -i '/NumberOfPages/r $EXTRACT_FILE' "$pdf_data"
+sed -i "/NumberOfPages/r $EXTRACT_FILE" "$pdf_data"
 
 echo "Creating new pdf with your bookmarks..."
 pdftk "$pdf" update_info_utf8 "$pdf_data" output "${pdf%.*}""_new.pdf"
 
 echo "Deleting leftovers"
-rm $EXTRACT_FILE "$pdf_data"
+rm "$EXTRACT_FILE" "$pdf_data"


### PR DESCRIPTION
There was a regression after closing #2.

Since `$EXTRACT_FILE` was inside single quotes,
it wasn't getting expanded, and thus none of the
`Bookmark` fields were getting added to the new
meta data file.)

We also add in some extra double quotes to prevent
word splitting.